### PR TITLE
Improve ping logic

### DIFF
--- a/dfs/src/connection.rs
+++ b/dfs/src/connection.rs
@@ -1,10 +1,10 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, ops::Deref, sync::Arc, time::Duration};
 
 use anyhow::Result;
 use async_raft::NodeId;
 use tarpc::{client::Config, context, serde_transport::tcp};
 use tokio::{
-    sync::{Mutex, OwnedMutexGuard, TryLockError},
+    sync::{watch, OwnedRwLockReadGuard, RwLock},
     task::JoinHandle,
     time,
 };
@@ -13,8 +13,8 @@ use tokio_serde::formats::MessagePack;
 use crate::{service::ServiceClient, CONFIG};
 
 pub struct NodeConnection {
-    client: Arc<Mutex<ServiceClient>>,
-    addr: SocketAddr,
+    client_ready: watch::Receiver<bool>,
+    client: Arc<RwLock<Option<ServiceClient>>>,
 
     pinger: JoinHandle<()>,
 }
@@ -25,63 +25,117 @@ async fn connect(addr: SocketAddr) -> Result<ServiceClient> {
     Ok(c)
 }
 
-impl NodeConnection {
-    pub async fn new(node_id: NodeId, addr: SocketAddr) -> Result<Self> {
-        let client = connect(addr).await?;
-        let client = Arc::new(Mutex::new(client));
-        let client_cpy = client.clone();
+async fn pinger(
+    node_id: NodeId,
+    client: Arc<RwLock<Option<ServiceClient>>>,
+    ready: watch::Sender<bool>,
+    addr: SocketAddr,
+) -> ! {
+    // TODO: add some randomization so that not all nodes fire pings all at the same time.
 
-        let pinger = tokio::spawn(async move {
-            // TODO: add some randomization so that not all nodes fire pings all at the same time.
-            // TODO: improve error handling when failing to connect after ping failure, this his
-            // highly likely to fail.
+    let mut interval = time::interval(CONFIG.ping_interval);
+    interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
 
-            let mut interval = time::interval(CONFIG.ping_interval);
-            interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
-            interval.reset(); // don't fire immediately
+    let mut missed_count = 0usize;
+    loop {
+        interval.tick().await;
 
-            let mut missed_count = 0usize;
-            loop {
-                interval.tick().await;
+        let mut lock = client.write().await;
 
-                {
-                    let mut client = client.lock().await;
-                    match client.ping(context::current()).await {
-                        Err(e) => {
-                            missed_count += 1;
-                            eprintln!(
-                                "error while pinging to {:?} (missed count {}/{}): {:?}",
-                                addr,
-                                missed_count + 1,
-                                CONFIG.max_missed_pings,
-                                e
-                            );
-
-                            if missed_count > CONFIG.max_missed_pings {
-                                eprintln!("reconnecting {} to {}", node_id, addr);
-                                *client = connect(addr).await.unwrap();
-                                missed_count = 0;
-                            }
-                        }
-                        Ok(()) => missed_count = 0,
+        let client = match lock.deref() {
+            None => loop {
+                let c = match connect(addr).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("error while connecting, retrying in 500ms: {:?}", e);
+                        time::sleep(Duration::from_millis(500)).await;
+                        continue;
                     }
+                };
+
+                missed_count = 0;
+                *lock = Some(c);
+                ready.send_replace(true);
+                break lock.deref().as_ref().unwrap();
+            },
+            Some(c) => c,
+        };
+
+        match client.ping(context::current()).await {
+            Err(e) => {
+                missed_count += 1;
+                eprintln!(
+                    "error while pinging to {:?} (missed count {}/{}): {:?}",
+                    addr,
+                    missed_count + 1,
+                    CONFIG.max_missed_pings,
+                    e
+                );
+
+                if missed_count > CONFIG.max_missed_pings {
+                    eprintln!("reconnecting {} to {}", node_id, addr);
+                    *lock = None;
+                    ready.send_replace(false);
                 }
             }
-        });
+            Ok(()) => {
+                missed_count = 0;
+            }
+        }
+    }
+}
 
-        Ok(Self {
-            client: client_cpy,
-            addr,
+impl NodeConnection {
+    /// Create a new connection, this will be initialised directly in the background.
+    pub async fn new(node_id: NodeId, addr: SocketAddr) -> Self {
+        let (ready_tx, ready_rx) = watch::channel(false);
+
+        let client = Arc::new(RwLock::new(None));
+        let client_cpy = client.clone();
+
+        let pinger = tokio::spawn(async move { pinger(node_id, client_cpy, ready_tx, addr).await });
+
+        Self {
+            client_ready: ready_rx,
+            client,
 
             pinger,
-        })
+        }
     }
 
-    pub async fn get_client(&self) -> OwnedMutexGuard<ServiceClient> {
-        self.client.clone().lock_owned().await
+    /// Retrieve a read lock to the client, locks until the client is ready and obtainable.
+    pub async fn get_client(&self) -> OwnedRwLockReadGuard<Option<ServiceClient>, ServiceClient> {
+        loop {
+            self.wait_is_ready().await;
+            let guard = self.client.clone().read_owned().await;
+            match guard.as_ref() {
+                None => continue,
+                Some(_) => {
+                    break OwnedRwLockReadGuard::map(guard, |l: &Option<ServiceClient>| {
+                        l.as_ref().unwrap()
+                    })
+                }
+            }
+        }
     }
 
-    pub fn try_get_client(&self) -> Result<OwnedMutexGuard<ServiceClient>, TryLockError> {
-        self.client.clone().try_lock_owned()
+    /// Returns whether or not the client is _currently_ ready to use.
+    pub fn is_client_ready(&self) -> bool {
+        *self.client_ready.borrow()
+    }
+
+    /// Waits until the client is marked as ready to use.
+    pub async fn wait_is_ready(&self) {
+        let mut rx = self.client_ready.clone();
+        if *rx.borrow_and_update() {
+            return;
+        }
+
+        loop {
+            rx.changed().await.unwrap();
+            if *rx.borrow() {
+                return;
+            }
+        }
     }
 }

--- a/dfs/src/network.rs
+++ b/dfs/src/network.rs
@@ -21,13 +21,12 @@ pub struct AppRaftNetwork {
 
 impl AppRaftNetwork {
     pub async fn new(config: Arc<Config>) -> Result<Self> {
-        let nodes: Vec<Result<_>> = iter(&CONFIG.nodes)
-            .then(|n| async move { anyhow::Ok((n.id, NodeConnection::new(n.id, n.addr).await?)) })
+        let nodes: HashMap<_, _> = iter(&CONFIG.nodes)
+            .then(|n| async move { (n.id, NodeConnection::new(n.id, n.addr).await) })
             .collect()
             .await;
-        let nodes: Result<HashMap<_, _>> = nodes.into_iter().collect();
 
-        Ok(Self { nodes: nodes? })
+        Ok(Self { nodes })
     }
 
     pub fn assume_node(&self, node_id: u64) -> Result<&NodeConnection> {


### PR DESCRIPTION
This PR improves the pinging logic in the sense that it allows ping task to keep trying to reconnect on a broken connection without halting the other tasks.

Callers can use `is_client_ready` to check whether or not the client is _currently_ ready without blocking. Of course, it might just so happen that when the client finally obtains the lock the connection has died.
`get_client` handles that corner case.
The only API change is that now the `new` function can't fail. I made sure to not change the signature of `get_client`.