### PR TITLE
fix prepend_fs_dir

### DIFF
--- a/dfs/src/util.rs
+++ b/dfs/src/util.rs
@@ -17,7 +17,7 @@ where
 }
 
 /// Prepend [Config]'s `fs_dir` to `file_path`, creating an absolute path to the file on any node in the filesystem.
-pub fn prepend_fs_dir(file_path: &Utf8Path) -> String {
+pub fn prepend_fs_dir(file_path: &Utf8Path) -> Utf8PathBuf {
     // TODO: similar for non-unix platforms.
     let file_path = if file_path.starts_with("/") {
         file_path.strip_prefix("/").unwrap()
@@ -27,7 +27,7 @@ pub fn prepend_fs_dir(file_path: &Utf8Path) -> String {
 
     let mut full_path = CONFIG.file_dir.clone();
     full_path.push(file_path);
-    full_path.into_string()
+    full_path
 }
 
 pub fn blob_to_hash(hash: &[u8]) -> Result<u64> {


### PR DESCRIPTION
Since we use absolute paths, we have to chop off the / at the beginning.
Ref: #22