### PR TITLE
Consistent use of NodeId, RaftLogId, RequestSerial and FileContentHash rather than u64

### DIFF
--- a/dfs/src/client_req.rs
+++ b/dfs/src/client_req.rs
@@ -3,12 +3,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::{operation::Operation, RAFT};
 
+/// Serial number the client has provided for this request.
+/// If the client sends the same request again, they will send it with the same serial number.
+pub type RequestSerial = u64;
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AppClientRequest {
     /// The ID of the client which has sent the request.
     pub client: NodeId,
     /// The serial number of this request.
-    pub serial: u64,
+    pub serial: RequestSerial,
 
     /// Operation that has to be performed.
     pub operation: Operation,

--- a/dfs/src/db/file.rs
+++ b/dfs/src/db/file.rs
@@ -3,7 +3,10 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use super::schema::{Schema, SqlxQuery};
-use crate::util::{blob_to_hash, flatten_result};
+use crate::{
+    filesystem::FileContentHash,
+    util::{blob_to_hash, flatten_result},
+};
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use futures::prelude::*;
@@ -16,7 +19,7 @@ pub struct FileRow {
     pub file_path: Utf8PathBuf,
     pub file_size: u64,
     pub modified_at: SystemTime,
-    pub content_hash: Option<u64>,
+    pub content_hash: Option<FileContentHash>,
     pub replication_factor: u64,
     /// `false` means this is a directory
     pub is_file: bool,
@@ -146,7 +149,7 @@ impl File {
     pub async fn update_file_hash(
         conn: &mut SqliteConnection,
         path: &Utf8Path,
-        hash: Option<u64>,
+        hash: Option<FileContentHash>,
     ) -> Result<()> {
         let hash = hash.map(|h| h.to_be_bytes().to_vec());
         let path = path.as_str();

--- a/dfs/src/db/keepers.rs
+++ b/dfs/src/db/keepers.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{query, sqlite::SqliteRow, Row, SqliteConnection};
 
 use super::nodes::NodeStatus;
-use crate::{util::blob_to_hash, RAFT};
+use crate::{filesystem::FileContentHash, util::blob_to_hash, RAFT};
 
 use super::schema::{Schema, SqlxQuery};
 
@@ -17,7 +17,7 @@ pub struct KeepersRow {
     pub id: i64,
     pub path: Utf8PathBuf,
     pub node_id: NodeId,
-    pub hash: u64,
+    pub hash: FileContentHash,
 }
 
 pub struct Keepers;
@@ -103,7 +103,7 @@ impl Keepers {
                 },
                 node_id: {
                     let id: i64 = row.get("node_id");
-                    u64::try_from(id)?
+                    NodeId::try_from(id)?
                 },
 
                 hash: blob_to_hash(row.get("hash"))?,

--- a/dfs/src/db/last_applied_entries.rs
+++ b/dfs/src/db/last_applied_entries.rs
@@ -37,7 +37,7 @@ impl LastAppliedEntries {
         .await?
         .map(|record| {
             Ok(LastAppliedEntry {
-                id: record.last_entry_id as u64,
+                id: record.last_entry_id as RaftLogId,
                 contents: bincode::deserialize(&record.last_entry_contents)
                     .map_err(raftlog_deserialize_error)?,
             })

--- a/dfs/src/db/outstanding_writes.rs
+++ b/dfs/src/db/outstanding_writes.rs
@@ -3,11 +3,13 @@ use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 use sqlx::{query, Error, SqliteConnection};
 
+use crate::client_req::RequestSerial;
+
 use super::schema::{Schema, SqlxQuery};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OutstandingWriteRow {
-    pub serial: u64,
+    pub serial: RequestSerial,
     pub file_path: Utf8PathBuf,
     pub node_id: i64,
 }

--- a/dfs/src/filesystem.rs
+++ b/dfs/src/filesystem.rs
@@ -18,6 +18,8 @@ use crate::{
     CONFIG,
 };
 
+pub type FileContentHash = u64;
+
 pub type Result<T> = std::result::Result<T, FileSystemError>;
 
 #[derive(Error, Debug)]
@@ -124,7 +126,7 @@ impl FileSystem {
         &self,
         _: &QueueReadHandle<'_>,
         path: impl AsRef<Utf8Path>,
-    ) -> Result<u64> {
+    ) -> Result<FileContentHash> {
         let file = File::open(self.map_path(path)).await?;
         let mut reader = BufReader::new(file);
 

--- a/dfs/src/network.rs
+++ b/dfs/src/network.rs
@@ -18,7 +18,7 @@ pub const CLIENT_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(1);
 /// A type which emulates a network transport and implements the `RaftNetwork` trait.
 #[derive(Debug)]
 pub struct AppRaftNetwork {
-    nodes: HashMap<u64, NodeConnection>,
+    nodes: HashMap<NodeId, NodeConnection>,
 }
 
 impl AppRaftNetwork {
@@ -68,7 +68,7 @@ impl RaftNetwork<AppClientRequest> for AppRaftNetwork {
     /// Send an AppendEntries RPC to the target Raft node (§5).
     async fn append_entries(
         &self,
-        target: u64,
+        target: NodeId,
         rpc: AppendEntriesRequest<AppClientRequest>,
     ) -> Result<AppendEntriesResponse> {
         let client = assume_client!(self, target, None);
@@ -78,7 +78,7 @@ impl RaftNetwork<AppClientRequest> for AppRaftNetwork {
     /// Send an InstallSnapshot RPC to the target Raft node (§7).
     async fn install_snapshot(
         &self,
-        target: u64,
+        target: NodeId,
         rpc: InstallSnapshotRequest,
     ) -> Result<InstallSnapshotResponse> {
         let client = assume_client!(self, target, None);
@@ -86,7 +86,7 @@ impl RaftNetwork<AppClientRequest> for AppRaftNetwork {
     }
 
     /// Send a RequestVote RPC to the target Raft node (§5).
-    async fn vote(&self, target: u64, rpc: VoteRequest) -> Result<VoteResponse> {
+    async fn vote(&self, target: NodeId, rpc: VoteRequest) -> Result<VoteResponse> {
         let client = assume_client!(self, target, None);
         Ok(client.vote(context::current(), rpc).await?)
     }

--- a/dfs/src/operation.rs
+++ b/dfs/src/operation.rs
@@ -4,6 +4,8 @@ use async_raft::NodeId;
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 
+use crate::{client_req::RequestSerial, filesystem::FileContentHash};
+
 /// Mutating operations that the Raft cluster can perform on the application's state machine (the file registry).
 /// An operation either comes from a fellow node (a [NodeToNodeOperation]) or a client (a [ClientToNodeOperation])
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -55,16 +57,16 @@ pub enum NodeToNodeOperation {
     /// Sent by a keeper when a previous file operation was unsuccessfully finished.
     FileCommitFail {
         /// The serial number of the operation to which this commit refers to.
-        serial: u64,
+        serial: RequestSerial,
         /// The reason this commit failed.
         failure_reason: String, // TODO: different type?
     },
     /// Sent by a keeper when a previous file operation was succesfully done.
     FileCommitSuccess {
         /// The serial number of the operation to which this commit refers to.
-        serial: u64,
+        serial: RequestSerial,
         /// XxHash64 value for the whole file content at this point, if any.
-        hash: Option<u64>,
+        hash: Option<FileContentHash>,
         /// The node this file was committed on
         node_id: NodeId,
         /// Path of the file that was committed

--- a/dfs/src/util.rs
+++ b/dfs/src/util.rs
@@ -1,4 +1,4 @@
-use crate::{config::Config, CONFIG};
+use crate::{config::Config, filesystem::FileContentHash, CONFIG};
 use anyhow::{anyhow, bail, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use webdav_handler::davpath::DavPath;
@@ -29,7 +29,7 @@ pub fn prepend_fs_dir(file_path: &Utf8Path) -> Utf8PathBuf {
     full_path
 }
 
-pub fn blob_to_hash(hash: &[u8]) -> Result<u64> {
+pub fn blob_to_hash(hash: &[u8]) -> Result<FileContentHash> {
     if hash.len() != 8 {
         bail!(
             "expected hash to be 8 bytes, but it is {} bytes",
@@ -39,7 +39,7 @@ pub fn blob_to_hash(hash: &[u8]) -> Result<u64> {
 
     let mut bytes: [u8; 8] = [0; 8];
     bytes.copy_from_slice(hash);
-    Ok(u64::from_be_bytes(bytes))
+    Ok(FileContentHash::from_be_bytes(bytes))
 }
 
 pub fn davpath_to_pathbuf(path: &DavPath) -> Utf8PathBuf {


### PR DESCRIPTION
Closes #51 